### PR TITLE
Resolve unsigned rounding case

### DIFF
--- a/benchmarks/cadence/abs_diff_shared_sub.bwlang
+++ b/benchmarks/cadence/abs_diff_shared_sub.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "abs_diff_shared_sub",
     "preconditions": [],
-    "lhs": "(bw w (+ (* (bw w (- (bw w a) (bw w b))) (bw 1 s)) (* (bw w (- (bw w b) (bw w a))) (bw 1 (not (bw 1 s))))))",
-    "rhs": "(bw w (- (bw w (+ (bw w (* (bw w a) (bw 1 s))) (bw w (* (bw w b) (bw 1 (not (bw 1 s))))))) (bw w (+ (bw w (* (bw w b) (bw 1 s))) (bw w (* (bw w a) (bw 1 (not (bw 1 s)))))))))"
+    "lhs": "(bw w (SEL (bw 1 s) (bw w (- (bw w a) (bw w b))) (bw w (- (bw w b) (bw w a)))))",
+    "rhs": "(bw w (- (bw w (SEL (bw 1 s) (bw w a) (bw w b))) (bw w (SEL (bw 1 s) (bw w b) (bw w a)))))"
 }

--- a/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
+++ b/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "unsigned_rounding_v0_to_v2",
-    "preconditions": ["(> w2 1)"],
-    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) 1)) (bw 1 a)))",
-    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) 1))"
+    "preconditions": ["(> w2 1)", "(>= (- (+ w2 1) w2) 1)", "(> 2 0)"],
+    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) (bw 1 1))) (bw 1 a)))",
+    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) (bw 1 1)))"
 }

--- a/benchmarks/cadence/unsigned_rounding_v1_to_v2.bwlang
+++ b/benchmarks/cadence/unsigned_rounding_v1_to_v2.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "unsigned_rounding_v1_to_v2",
-    "preconditions": ["(> w2 1)"],
+    "preconditions": ["(> w2 1)", "(>= (- (+ w2 1) w2) 1)", "(> 2 0)"],
     "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) 1)) (bw w2 (bw 1 a))))",
     "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) 1))"
 }

--- a/benchmarks/rover/move_sel_zero.bwlang
+++ b/benchmarks/rover/move_sel_zero.bwlang
@@ -1,0 +1,6 @@
+{
+    "name": "move_sel_zero",
+    "preconditions": ["(>= p 1)", "(>= q 1)"],
+    "lhs": "(bw r (* (bw p (SEL (bw 1 b) (bw p 0) (bw p a))) (bw q c)))",
+    "rhs": "(bw r (*  (bw p a) (bw q (SEL (bw 1 b) (bw q 0) (bw q c)))))"
+}

--- a/benchmarks/rover/sel_add.bwlang
+++ b/benchmarks/rover/sel_add.bwlang
@@ -1,0 +1,6 @@
+{
+    "name": "sel_add",
+    "preconditions": [],
+    "lhs": "(bw w (SEL (bw 1 s) (bw w (+ (bw w a) (bw w b))) (bw w (+ (bw w c) (bw w d)))))",
+    "rhs": "(bw w (+ (bw w (SEL (bw 1 s) (bw w a) (bw w c))) (bw w (SEL (bw 1 s) (bw w b) (bw w d)))))"
+}

--- a/benchmarks/rover/sel_add_zero.bwlang
+++ b/benchmarks/rover/sel_add_zero.bwlang
@@ -1,0 +1,6 @@
+{
+    "name": "sel_add_zero",
+    "preconditions": [],
+    "lhs": "(bw w (SEL (bw 1 s) (bw w (+ (bw w a) (bw w b))) (bw w (+ (bw w c) (bw w d)))))",
+    "rhs": "(bw w (+ (bw w (SEL (bw 1 s) (bw w a) (bw w c))) (bw w (SEL (bw 1 s) (bw w b) (bw w d)))))"
+}

--- a/src/language.rs
+++ b/src/language.rs
@@ -21,6 +21,7 @@ define_language! {
         "or" = Or([Id;2]),
         "xor" = Xor([Id;2]),
         "not" = Not([Id; 1]),
+        "SEL" = Select([Id;3]),
         // Operators to handle preconditions
         ">"  = GT([Id; 2]),
         ">=" = GTE([Id; 2]),

--- a/src/rewrite_rules.rs
+++ b/src/rewrite_rules.rs
@@ -24,6 +24,8 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         rewrite!("div_pow_join";    "(div (div ?a ?b) ?c)"      => "(div ?a (* ?b ?c))" if precondition(&["(> ?c 0)"])),
         rewrite!("div_mult_self";   "(div (+ ?a (* ?b ?c)) ?b)" => "(+ (div ?a ?b) ?c)" if precondition(&["(> ?b 0)"])),
         rewrite!("div_same";        "(div (* ?a ?b) ?a)"        => "?b"                 if precondition(&["(> ?a 0)"])),
+        rewrite!("shift_mod"; "(bw ?q (>> (bw ?p ?a) ?b))" => "(bw ?q (>> ?a ?b))" if precondition(&["(>= (- ?p ?q) ?b)"])),
+        rewrite!("div-by-more"; "(div (bw 1 ?a) 2)" => "0"),
         /////////////////////////
         //      MOD RELATED    //
         /////////////////////////
@@ -77,6 +79,7 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         // shift operations
         rewrite!("shl_def"; "(<< (bw ?p ?a) (bw ?q ?b))" => "(* (bw ?p ?a) (^ 2 (bw ?q ?b)))"),
         rewrite!("shr_def"; "(>> (bw ?p ?a) (bw ?q ?b))" => "(div (bw ?p ?a) (^ 2 (bw ?q ?b)))"),
+        rewrite!("shr_def_danger"; "(>> ?a ?b)" => "(div ?a (^ 2 ?b))"),
         // bitwise ring? properties
         rewrite!("or.commute";     "(or ?a ?b)" => "(or ?b ?a)"),
         rewrite!("or_assoc";       "(or (or ?a ?b) ?c)" => "(or ?a (or ?b ?c))"),
@@ -84,8 +87,10 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         rewrite!("and_assoc";      "(and (and ?a ?b) ?c)" => "(and ?a (and ?b ?c))"),
         // bitwise identities
         rewrite!("and_allones";     "(and (bw ?p ?a) (bw ?p -1))" => "(bw ?p ?a)"),
+        rewrite!("and_one";         "(and (bw ?p ?a) 1)" => "(bw 1 ?a)"),
         rewrite!("or_allones";      "(or (bw ?p ?a) (bw ?p -1))" => "(bw ?p -1)"),
         rewrite!("xor_allones";     "(bw ?p (xor (bw ?p ?a) (bw ?p -1)))" => "(bw ?p (not (bw ?p ?a)))"),
+        rewrite!("xor_one";         "(xor (bw ?p ?a) 1)" => "(+ (* (div (bw ?p ?a) 2) 2) (bw 1 (not (bw 1 ?a))))"),
         rewrite!("and_self";        "(and ?a ?a)" => "?a"),
         rewrite!("or_self";         "(or ?a ?a)" =>  "?a"),
         rewrite!("and_not_self";    "(and (bw ?p ?a) (bw ?p (not (bw ?p ?a))))" => "0"),
@@ -103,9 +108,9 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
     // bitwise to arith
     rules.extend(rewrite!("neg_not"; "(- (bw ?p ?a))" <=> "(+ (not (bw ?p ?a)) 1)"));
     rules.extend(rewrite!("add_as_xor_and";
-        "(+ (bw ?p ?a) (bw ?p ?b))"
+        "(+ (bw ?p ?a) (bw ?q ?b))"
             <=>
-        "(+ (xor (bw ?p ?a) (bw ?p ?b)) (* 2 (and (bw ?p ?a) (bw ?p ?b))))"
+        "(+ (xor (bw ?p ?a) (bw ?q ?b)) (* 2 (and (bw ?p ?a) (bw ?q ?b))))"
     ));
     rules.extend(rewrite!("xor_as_or_and";
         "(xor (bw ?p ?a) (bw ?p ?b))"

--- a/src/rewrite_rules.rs
+++ b/src/rewrite_rules.rs
@@ -81,7 +81,7 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         // shift operations
         rewrite!("shl_def"; "(<< (bw ?p ?a) (bw ?q ?b))" => "(* (bw ?p ?a) (^ 2 (bw ?q ?b)))"),
         rewrite!("shr_def"; "(>> (bw ?p ?a) (bw ?q ?b))" => "(div (bw ?p ?a) (^ 2 (bw ?q ?b)))"),
-        rewrite!("shr_def_danger"; "(>> ?a ?b)" => "(div ?a (^ 2 ?b))"),
+        rewrite!("shr_by_pos"; "(>> ?a ?b)" => "(div ?a (^ 2 ?b))" if precondition(&["(> ?b 0)"])),
         // bitwise ring? properties
         rewrite!("or.commute";     "(or ?a ?b)" => "(or ?b ?a)"),
         rewrite!("or_assoc";       "(or (or ?a ?b) ?c)" => "(or ?a (or ?b ?c))"),

--- a/src/rewrite_rules.rs
+++ b/src/rewrite_rules.rs
@@ -56,6 +56,8 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         rewrite!("mul_full_prec";   "(bw ?r (* (bw ?q ?a) (bw ?p ?b)))"
                                  => "(* (bw ?q ?a) (bw ?p ?b))"
                                     if precondition(&["(>= ?r (+ ?p ?q))"])),
+        rewrite!("mul_by_bit";      "(bw ?p (* (bw ?p ?a) (bw 1 ?b)))"
+                                    => "(* (bw ?p ?a) (bw 1 ?b))"),
         // precision loss due to smaller outer mod
         rewrite!("mul_remove_prec"; "(bw ?q (* (bw ?p ?a) ?b))"
                                  => "(bw ?q (* ?a ?b))"
@@ -103,6 +105,7 @@ pub fn rules() -> Vec<Rewrite<ModIR, ModAnalysis>> {
         rewrite!("xor_remove"; "(bw ?p (xor (bw ?p ?a) (bw ?p ?b)))" => "(xor (bw ?p ?a) (bw ?p ?b))"),
         rewrite!("demorg_and"; "(bw ?p (not (and (bw ?p ?a) (bw ?p ?b))))" => "(bw ?p (or (bw ?p (not (bw ?p ?a))) (bw ?p (not (bw ?p ?b)))))"),
         rewrite!("demorg_or";  "(bw ?p (not (or (bw ?p ?a) (bw ?p ?b))))" => "(bw ?p (and (bw ?p (not (bw ?p ?a))) (bw ?p (not (bw ?p ?b)))))"),
+        rewrite!("select-to-mult"; "(SEL (bw 1 ?cond) (bw ?p ?a) (bw ?p ?b))" => "(+ (bw ?p (* (bw ?p ?a) (bw 1 ?cond))) (bw ?p (* (bw ?p ?b) (bw 1 (not (bw 1 ?cond))))))"),
     ];
     rules.extend(rewrite!("xor_and_or";      "(and (or (bw ?p ?a) (bw ?p ?b)) (or (bw ?p (not (bw ?p ?a))) (bw ?p (not (bw ?p ?b)))))" <=> "(xor (bw ?p ?a) (bw ?p ?b))"));
     // bitwise to arith


### PR DESCRIPTION
Update the conditions for the unsigned rounding cases- bit silly but will be resolved by Z3.

Add the following rules (which can and should be generalized in many cases):

- "(>> ?a ?b)" => "(div ?a (^ 2 ?b))"
- "(and (bw ?p ?a) 1)" => "(bw 1 ?a)"
- "(xor (bw ?p ?a) 1)" => "(+ (* (div (bw ?p ?a) 2) 2) (bw 1 (not (bw 1 ?a))))"
- (?q - ?p) > ?b => "(bw ?q (>> (bw ?p ?a) ?b))" => "(bw ?q (>> ?a ?b))"
- "(div (bw 1 ?a) 2)" => "0"