### PR TITLE
Fix the conversion from bwlang to pbv

### DIFF
--- a/benchmarks/alive_mixed/AndOrXor_2515.bwlang
+++ b/benchmarks/alive_mixed/AndOrXor_2515.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "AndOrXor_2515",
-    "lhs": "(bw k (xor (bw k (>> (bw k (xor (bw k var_x) (bw k C1))) (bw k C2))) (bw k C3)))",
-    "rhs": "(bw k (xor (bw k (>> (bw k var_x) (bw k C2))) (bw k (xor (bw k (>> (bw k C1) (bw k C2))) (bw k C3)))))",
-    "preconditions": [
-        "(< (bw k C2) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift239.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift239.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift239",
-    "lhs": "(bw k (>> (bw k (<< (bw k var_X) (bw k C))) (bw k C)))",
-    "rhs": "(bw k (and (bw k var_X) (bw k (>> (bw k -1) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift279.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift279.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift279",
-    "lhs": "(bw k (<< (bw k (>> (bw k var_X) (bw k C))) (bw k C)))",
-    "rhs": "(bw k (and (bw k var_X) (bw k (<< (bw k -1) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift440.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift440.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift440",
-    "lhs": "(bw k (<< (bw k (xor (bw k var_Y) (bw k (and (bw k (>> (bw k var_X) (bw k C))) (bw k C2))))) (bw k C)))",
-    "rhs": "(bw k (xor (bw k (and (bw k var_X) (bw k (<< (bw k C2) (bw k C))))) (bw k (<< (bw k var_Y) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift476.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift476.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift476",
-    "lhs": "(bw k (<< (bw k (or (bw k (and (bw k (>> (bw k var_X) (bw k C))) (bw k C2))) (bw k var_Y))) (bw k C)))",
-    "rhs": "(bw k (or (bw k (and (bw k var_X) (bw k (<< (bw k C2) (bw k C))))) (bw k (<< (bw k var_Y) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift497a.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift497a.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift497a",
-    "lhs": "(bw k (>> (bw k (xor (bw k var_X) (bw k C2))) (bw k C)))",
-    "rhs": "(bw k (xor (bw k (>> (bw k var_X) (bw k C))) (bw k (>> (bw k C2) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/InstCombineShift582.bwlang
+++ b/benchmarks/alive_mixed/InstCombineShift582.bwlang
@@ -1,8 +1,0 @@
-{
-    "name": "InstCombineShift582",
-    "lhs": "(bw k (>> (bw k (<< (bw k var_X) (bw k C))) (bw k C)))",
-    "rhs": "(bw k (and (bw k var_X) (bw k (>> (bw k -1) (bw k C)))))",
-    "preconditions": [
-        "(< (bw k C) (bw k 4))"
-    ]
-}

--- a/benchmarks/alive_mixed/fails.txt
+++ b/benchmarks/alive_mixed/fails.txt
@@ -1,7 +1,0 @@
-AndOrXor_2515
-InstCombineShift239
-InstCombineShift279
-InstCombineShift440
-InstCombineShift476
-InstCombineShift497a
-InstCombineShift582

--- a/benchmarks/cadence/abs_diff_shared_sub.bwlang
+++ b/benchmarks/cadence/abs_diff_shared_sub.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "abs_diff_shared_sub",
     "preconditions": [],
-    "lhs": "(bw w (+ (* (bw w (- (bw w a) (bw w b))) (bw 1 s)) (* (bw w (- (bw w b) (bw w a))) (bw 1 (not (bw 1 s))))))",
+    "lhs": "(bw w (+ (bw w (* (bw w (- (bw w a) (bw w b))) (bw 1 s))) (bw w (* (bw w (- (bw w b) (bw w a))) (bw 1 (not (bw 1 s)))))))",
     "rhs": "(bw w (- (bw w (+ (bw w (* (bw w a) (bw 1 s))) (bw w (* (bw w b) (bw 1 (not (bw 1 s))))))) (bw w (+ (bw w (* (bw w b) (bw 1 s))) (bw w (* (bw w a) (bw 1 (not (bw 1 s)))))))))"
 }

--- a/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
+++ b/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "unsigned_rounding_v0_to_v2",
     "preconditions": ["(> w2 1)"],
-    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) (bw 1 1))) (bw 1 a)))",
+    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) (bw 1 1))) (bw 1 (bw (+ w2 1) a))))",
     "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) (bw 1 1)))"
 }

--- a/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
+++ b/benchmarks/cadence/unsigned_rounding_v0_to_v2.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "unsigned_rounding_v0_to_v2",
     "preconditions": ["(> w2 1)"],
-    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) 1)) (bw 1 a)))",
-    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) 1))"
+    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) (bw 1 1))) (bw 1 a)))",
+    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) (bw 1 1)))"
 }

--- a/benchmarks/cadence/unsigned_rounding_v1_to_v2.bwlang
+++ b/benchmarks/cadence/unsigned_rounding_v1_to_v2.bwlang
@@ -1,6 +1,6 @@
 {
     "name": "unsigned_rounding_v1_to_v2",
     "preconditions": ["(> w2 1)"],
-    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) 1)) (bw w2 (bw 1 a))))",
-    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) 1))"
+    "lhs": "(bw w2 (+ (bw w2 (>> (bw (+ w2 1) a) (bw 1 1))) (bw w2 (bw 1 (bw (+ w2 1) a)))))",
+    "rhs": "(bw w2 (>> (bw (+ w2 1) (+ (bw (+ w2 1) a) (bw 1 1))) (bw 1 1)))"
 }

--- a/build.rs
+++ b/build.rs
@@ -145,14 +145,13 @@ fn main() {
 #[test]
 #[allow(non_snake_case)]
 fn {fn_name}_validate() {{
-    let mut eq = Equivalence::new(
+    let eq = Equivalence::new(
         {name_literal},
         &{preconditions},
         {lhs_literal},
         {rhs_literal},
     );
-    eq = eq.find_equivalence(&None);
-    assert!(eq.validate().is_ok());
+    assert!(eq.validate().is_ok(), "{{:#?}}", eq.validate().err());
 }}
 
 #[test]
@@ -165,8 +164,8 @@ fn {fn_name}_find_equiv() {{
         {lhs_literal},
         {rhs_literal},
     );
-    eq = eq.find_equivalence(&None);
     assert!(eq.validate().is_ok());
+    eq = eq.find_equivalence(&None);
     assert!(eq.equiv.is_some_and(|x| x), "Equivalence was not found.\n{{}}", eq.explanation_string());
     eq = eq.make_proof();
     let _expl = eq.explanation_string();

--- a/build.rs
+++ b/build.rs
@@ -143,9 +143,22 @@ fn main() {
                 output,
                 r#"
 #[test]
+#[allow(non_snake_case)]
+fn {fn_name}_validate() {{
+    let mut eq = Equivalence::new(
+        {name_literal},
+        &{preconditions},
+        {lhs_literal},
+        {rhs_literal},
+    );
+    eq = eq.find_equivalence(&None);
+    assert!(eq.validate().is_ok());
+}}
+
+#[test]
 {should_panic_attr}#[cfg_attr(not(feature = "isabelle-check"), timeout(10000))]
 #[allow(non_snake_case)]
-fn {fn_name}() {{
+fn {fn_name}_find_equiv() {{
     let mut eq = Equivalence::new(
         {name_literal},
         &{preconditions},

--- a/src/param_ir.rs
+++ b/src/param_ir.rs
@@ -41,6 +41,7 @@ define_language! {
         "<"  = LT([Id; 2]),
         "<=" = LTE([Id; 2]),
         "=" = Eq([Id;2]),
+        "int_to_pbv" = IntToPBV([Id;2]),
         // Numbers and associated width expr (must be num or var)
         Num(Num, Id),
         // Variables and associate width expr (must be num or var)
@@ -538,8 +539,6 @@ pub fn pbvvar_to_smt_string(var: &RecExpr<ParamIR>) -> String {
 }
 
 pub fn rewrite_var_to_wvar(expr: &RecExpr<ParamIR>) -> RecExpr<ParamIR> {
-    let mut expr_out: RecExpr<ParamIR> = RecExpr::default();
-
     fn rec_call<'a>(
         expr_in: &RecExpr<ParamIR>,
         id_in: Id,
@@ -550,6 +549,16 @@ pub fn rewrite_var_to_wvar(expr: &RecExpr<ParamIR>) -> RecExpr<ParamIR> {
             ParamIR::Var(sym, _w) => {
                 let id = exprout.add(ParamIR::WVar(*sym));
                 (id, exprout)
+            }
+            ParamIR::Num(val, w) => {
+                // Produce an smt pbv compliant bv
+                // either use int_to_pbv if the width isn't a constant, else use (_ bv{num} {width})
+                // or just use int_to_pbv
+                // do this as well by hacking the WVar which allows for arbitrary string
+                let (w_id, tmp) = rec_call(expr_in, *w, exprout);
+                let num_id = tmp.add(ParamIR::WNum(*val));
+                let id = tmp.add(ParamIR::IntToPBV([w_id, num_id]));
+                (id, tmp)
             }
             op => {
                 let mut new_childs = HashMap::<Id, Id>::new();
@@ -566,6 +575,7 @@ pub fn rewrite_var_to_wvar(expr: &RecExpr<ParamIR>) -> RecExpr<ParamIR> {
         }
     }
 
+    let mut expr_out: RecExpr<ParamIR> = RecExpr::default();
     let (_final_id, final_exp) = rec_call(expr, expr.root(), &mut expr_out);
 
     final_exp.clone()

--- a/src/param_ir.rs
+++ b/src/param_ir.rs
@@ -195,12 +195,12 @@ fn case_split_binary(
             .parse()
             .unwrap(),
         ),
-        // width_out < max(w(a), w(b)) & w(a) < w(b)
+        // width_out < max(w(a), w(b))
+        // w_o < w(b) & w(b) > w(a)
         (
             vec![
-                format!("(< {w_out} {w_a})").parse().unwrap(),
                 format!("(< {w_out} {w_b})").parse().unwrap(),
-                format!("(< {w_a} {w_b})").parse().unwrap(),
+                format!("(> {w_b} {w_a})").parse().unwrap(),
             ],
             format!(
                 "(pextract (- {w_out} 1) 0 ({op} (pzero_extend (- {w_b} {w_a}) {expr_a}) {expr_b}))"
@@ -208,11 +208,10 @@ fn case_split_binary(
             .parse()
             .unwrap(),
         )
-        // width_out < max(w(a), w(b)) & w(a) = w(b)
+        // w_o < w(a) & w(a) = w(b)
         ,(
             vec![
                 format!("(< {w_out} {w_a})").parse().unwrap(),
-                format!("(< {w_out} {w_b})").parse().unwrap(),
                 format!("(= {w_a} {w_b})").parse().unwrap(),
             ],
             format!(
@@ -221,11 +220,10 @@ fn case_split_binary(
             .parse()
             .unwrap(),
         )
-        // width_out < max(w(a), w(b)) & w(a) > w(b)
+        // w_o < w(a) & w(a) > w(b)
         ,(
             vec![
                 format!("(< {w_out} {w_a})").parse().unwrap(),
-                format!("(< {w_out} {w_b})").parse().unwrap(),
                 format!("(> {w_a} {w_b})").parse().unwrap(),
             ],
             format!(

--- a/src/param_ir.rs
+++ b/src/param_ir.rs
@@ -158,41 +158,39 @@ fn case_split_binary(
                 .parse()
                 .unwrap(),
         ),
-        // width_out = max(w(a), w(b)) & w(a) < w(b)
+        // width_out = max(w(a), w(b))
+        // w_o = w(a) & w(a) > w(b)
         (
             vec![
                 format!("(= {w_out} {w_a})").parse().unwrap(),
-                format!("(= {w_out} {w_b})").parse().unwrap(),
-                format!("(< {w_a} {w_b})").parse().unwrap(),
+                format!("(> {w_a} {w_b})").parse().unwrap(),
                 ],
             format!(
-                "({op} (pzero_extend (- {w_b} {w_a}) {expr_a}) {expr_b})"
+                "({op} {expr_a} (pzero_extend (- {w_a} {w_b}) {expr_b})))"
             )
             .parse()
             .unwrap(),
         ),
-        // width_out = max(w(a), w(b)) & w(a) = w(b)
+        // w_o = w(a) & w(a) = w(b)
         (
             vec![
                 format!("(= {w_out} {w_a})").parse().unwrap(),
-                format!("(= {w_out} {w_b})").parse().unwrap(),
                 format!("(= {w_a} {w_b})").parse().unwrap(),
-            ],
+                ],
             format!(
                 "({op} {expr_a} {expr_b})"
             )
             .parse()
             .unwrap(),
         ),
-        // width_out = max(w(a), w(b)) & w(a) > w(b)
+        // w_o = w(b) & w(a) < w(b)
         (
             vec![
-                format!("(= {w_out} {w_a})").parse().unwrap(),
                 format!("(= {w_out} {w_b})").parse().unwrap(),
-                format!("(> {w_a} {w_b})").parse().unwrap(),
-            ],
+                format!("(< {w_a} {w_b})").parse().unwrap(),
+                ],
             format!(
-                "({op} {expr_a} (pzero_extend (- {w_a} {w_b}) {expr_b})))"
+                "({op} (pzero_extend (- {w_b} {w_a}) {expr_a}) {expr_b})"
             )
             .parse()
             .unwrap(),
@@ -322,7 +320,20 @@ pub fn modir_to_paramir(expr_in: &RecExpr<ModIR>, id: Id) -> Result<ParamInfo, S
                             })
                             .filter(|(cond, _expr)| {
                                 // Filter the generated conditions to the ones that are meaningful
-                                compatible_conds(cond).expect("Failed to evaluate condition")
+                                println!("{}", _expr.to_string());
+                                let width_gt_zero = cond
+                                    .into_iter()
+                                    .flat_map(|c| c.get_width_var())
+                                    .collect::<HashSet<ParamIR>>()
+                                    .into_iter()
+                                    .map(|w| {
+                                        format!("(> {} 0)", w.to_string())
+                                            .parse::<RecExpr<ParamIR>>()
+                                            .unwrap()
+                                    })
+                                    .collect::<Vec<RecExpr<ParamIR>>>();
+                                compatible_conds(cond.into_iter().chain(&width_gt_zero))
+                                    .expect("Failed to evaluate condition")
                             })
                             .collect::<Vec<_>>()
                         })
@@ -534,9 +545,10 @@ where
             );
         }
     }
-
     let res = solver.check();
-
+    println!("Checking condition:\n{}\n{:#?}", solver.to_string(), res);
+    // if res == SatResult::Sat {
+    // }
     if res == SatResult::Unknown {
         Err(format!(
             "Z3 returned unkown for this problem: {}",

--- a/src/param_ir.rs
+++ b/src/param_ir.rs
@@ -264,6 +264,34 @@ fn case_split_unary(
     [case_one, case_two, case_three]
 }
 
+fn case_split_mod(
+    w_a: &RecExpr<ParamIR>,
+    expr_a: &RecExpr<ParamIR>,
+    w_out: &RecExpr<ParamIR>,
+) -> [(Vec<RecExpr<ParamIR>>, RecExpr<ParamIR>); 3] {
+    // three cases
+    // w_out > w_a
+    let case_one: (Vec<RecExpr<ParamIR>>, RecExpr<ParamIR>) = (
+        vec![format!("(> {w_out} {w_a})").parse().unwrap()],
+        format!("(pzero_extend (- {w_out} {w_a}) {expr_a})")
+            .parse()
+            .unwrap(),
+    );
+    // w_out = w_a
+    let case_two: (Vec<RecExpr<ParamIR>>, RecExpr<ParamIR>) = (
+        vec![format!("(= {w_out} {w_a})").parse().unwrap()],
+        format!("{expr_a}").parse().unwrap(),
+    );
+    // w_out < w_a
+    let case_three: (Vec<RecExpr<ParamIR>>, RecExpr<ParamIR>) = (
+        vec![format!("(< {w_out} {w_a})").parse().unwrap()],
+        format!("(pextract (- {w_out} 1) 0 {expr_a})")
+            .parse()
+            .unwrap(),
+    );
+    [case_one, case_two, case_three]
+}
+
 /// This function takes a ModIR expression and enumerates all of the width conditions
 /// in order to generate all possible combinations of width extensions and truncations
 /// that would occur when performing verilog width processing.
@@ -318,7 +346,6 @@ pub fn modir_to_paramir(expr_in: &RecExpr<ModIR>, id: Id) -> Result<ParamInfo, S
                             })
                             .filter(|(cond, _expr)| {
                                 // Filter the generated conditions to the ones that are meaningful
-                                println!("{}", _expr.to_string());
                                 let width_gt_zero = cond
                                     .into_iter()
                                     .flat_map(|c| c.get_width_var())
@@ -400,7 +427,32 @@ pub fn modir_to_paramir(expr_in: &RecExpr<ModIR>, id: Id) -> Result<ParamInfo, S
                     )],
                 });
             }
-            ModIR::Mod(_) => todo!(),
+            ModIR::Mod([_w_child, _a]) => {
+                // Instead of analysing the child (a), recurse on the current node
+                // (bw p (bw q a)), here we are analysing (bw p (bw q ?))
+                // and we want to know what the resulting width of (bw q ?) and extend it or truncate it from q to p
+                // therefore, recurse on (bw q ?) to figure out that this is a variable a of width q
+                let info_a = modir_to_paramir(expr_in, *e)?;
+                let width_out = modir_w_to_paramir_w(expr_in, *w)?;
+                let combined_exprs = info_a
+                    .expr_out
+                    .iter()
+                    .flat_map(|(w_conds, expr_a)| {
+                        case_split_mod(&info_a.width_out, expr_a, &width_out)
+                            .iter_mut()
+                            .map(|(cond, expr)| {
+                                cond.append(&mut w_conds.clone());
+                                (cond.to_vec(), expr.clone())
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
+
+                Ok(ParamInfo {
+                    width_out,
+                    expr_out: combined_exprs,
+                })
+            }
             node => Err(format!("Invalid node type reached: {node}")),
         },
         _ => unreachable!(),
@@ -544,9 +596,6 @@ where
         }
     }
     let res = solver.check();
-    println!("Checking condition:\n{}\n{:#?}", solver.to_string(), res);
-    // if res == SatResult::Sat {
-    // }
     if res == SatResult::Unknown {
         Err(format!(
             "Z3 returned unkown for this problem: {}",

--- a/src/param_ir.rs
+++ b/src/param_ir.rs
@@ -320,6 +320,10 @@ pub fn modir_to_paramir(expr_in: &RecExpr<ModIR>, id: Id) -> Result<ParamInfo, S
                                 let expr: RecExpr<ParamIR> = expr.clone();
                                 (cond, expr)
                             })
+                            .filter(|(cond, _expr)| {
+                                // Filter the generated conditions to the ones that are meaningful
+                                compatible_conds(cond).expect("Failed to evaluate condition")
+                            })
                             .collect::<Vec<_>>()
                         })
                     })


### PR DESCRIPTION
- Generate integer constants of parametric width
- Introduce separate testcases for validation
- Remove benchmarks containing data preconditions
- Fix cadence testcases that were missing some bitwidth descriptions